### PR TITLE
Pact Invocations Compatibility

### DIFF
--- a/Class_Warlock/PactInvocations/OneDnD_PactInvocations/Mods/OneDnD_PactInvocations/ScriptExtender/CompatibilityFrameworkConfig.json
+++ b/Class_Warlock/PactInvocations/OneDnD_PactInvocations/Mods/OneDnD_PactInvocations/ScriptExtender/CompatibilityFrameworkConfig.json
@@ -32,6 +32,11 @@
       "UUIDs": [ "a7767dc5-e6ab-4e05-96fd-f0424256121c", "20015e25-8aa9-41bf-b959-aa587ba0aa27" ],
       "Selectors": [
         {
+          "Action": "Remove",
+          "Function": "SelectPassives",
+          "UUID": "333fb1b0-9398-4ca8-953e-6c0f9a59bbed"
+        },
+        {
           "Action": "Insert",
           "Function": "SelectPassives",
           "Params": {

--- a/Class_Warlock/PactInvocations/OneDnD_PactInvocations/Mods/OneDnD_PactInvocations/meta.lsx
+++ b/Class_Warlock/PactInvocations/OneDnD_PactInvocations/Mods/OneDnD_PactInvocations/meta.lsx
@@ -22,10 +22,10 @@
           <attribute id="Tags" type="LSWString" value="Template;Example" />
           <attribute id="Type" type="FixedString" value="Mod" />
           <attribute id="UUID" type="FixedString" value="c1cfc0d3-1dad-0000-0000-c01200000004" />
-          <attribute id="Version64" type="int64" value="36310271995674624" />
+          <attribute id="Version64" type="int64" value="36310276290641920" />
           <children>
             <node id="PublishVersion">
-              <attribute id="Version64" type="int64" value="36310271995674624" />
+              <attribute id="Version64" type="int64" value="36310276290641920" />
             </node>
             <node id="Scripts" />
             <node id="TargetModes">


### PR DESCRIPTION
Minor Compatibility Check: Attempts to remove Invocations from level 1 before adding the list to prevent double ups by other mods.